### PR TITLE
Adapted for the testing environment and added the rate_limit decorator for API rate limiting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ pip install -r requirements.txt
 - Fill in your API keys and configuration:
   ```
   OPENAI_API_KEY=your_openai_api_key
+  OPENAI_BASE_URL=https://your-custom-openai-url.com
   GOOGLE_PLACES_API_KEY=your_google_places_api_key
   REDIS_URL=redis://localhost:6379
   PINECONE_API_KEY=your_pinecone_api_key

--- a/app/agentic_itinerary.py
+++ b/app/agentic_itinerary.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 # Feature flag for agentic system
 ENABLE_AGENTIC_SYSTEM = os.getenv("ENABLE_AGENTIC_SYSTEM", "false").lower() == "true"
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
 
 @dataclass
 class AgentState:
@@ -96,7 +97,8 @@ class EnhancedAgenticItinerarySystem:
             model_name="gpt-3.5-turbo",  # Keep gpt-3.5-turbo for regeneration speed
             temperature=0.3,
             max_tokens=2000,
-            request_timeout=10  # Reduced timeout for performance
+            request_timeout=10,  # Reduced timeout for performance
+            **({"base_url": OPENAI_BASE_URL} if OPENAI_BASE_URL else {})  # Use base_url if set, otherwise use default
         )
         
         # Fast LLM for parallel day generation - use GPT-4-turbo as requested
@@ -106,6 +108,7 @@ class EnhancedAgenticItinerarySystem:
             temperature=0.3,
             max_tokens=1500,
             request_timeout=15  # Reduced timeout for performance
+            **({"base_url": os.getenv("OPENAI_BASE_URL")} if os.getenv("OPENAI_BASE_URL") else {})
         )
         
         # Thread pool for CPU-bound operations

--- a/app/complete_itinerary.py
+++ b/app/complete_itinerary.py
@@ -103,6 +103,7 @@ def get_cache_key(selection: LandmarkSelection) -> str:
 
 load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
 
 # OPTIMIZATION 1: Use GPT-4-turbo as primary model for quality (user confirmed GPT-3.5-turbo produces inconsistent results)
 llm = ChatOpenAI(
@@ -111,6 +112,7 @@ llm = ChatOpenAI(
     temperature=0.3,  # Lower temperature = more consistent generation
     max_tokens=2000,  # Reduced from 2500 to potentially speed up generation
     request_timeout=25,  # Reasonable timeout for quality model
+    **({"base_url": OPENAI_BASE_URL} if OPENAI_BASE_URL else {})  # Use base_url if set, otherwise use default
 )
 parser = PydanticOutputParser(pydantic_object=StructuredItinerary)
 fallback_parser = OutputFixingParser.from_llm(llm=llm, parser=parser)
@@ -122,6 +124,7 @@ backup_llm = ChatOpenAI(
     temperature=0.3,
     max_tokens=2000,  # Reduced from 2500
     request_timeout=15,  # Shorter timeout for backup model
+    **({"base_url": OPENAI_BASE_URL} if OPENAI_BASE_URL else {})  # Use base_url if set, otherwise use default
 )
 backup_fallback_parser = OutputFixingParser.from_llm(llm=backup_llm, parser=parser)
 

--- a/app/main.py
+++ b/app/main.py
@@ -154,8 +154,8 @@ class ItineraryRequest(BaseModel):
         
         raise ValueError('Either travel_days or both start_date and end_date must be provided')
 
-@rate_limit(endpoint="generate", limit=50)
 @app.post("/generate")
+@rate_limit(endpoint="generate", limit=50)
 async def generate(request: ItineraryRequest):
     try:
         recommendation_generator = app_state["recommendation_generator"]
@@ -181,8 +181,8 @@ async def generate(request: ItineraryRequest):
         logging.exception("Error during /generate")
         raise HTTPException(status_code=500, detail=str(e))
 
-@rate_limit(endpoint="complete_itinerary", limit=50)
 @app.post("/complete-itinerary", response_model=StructuredItinerary)
+@rate_limit(endpoint="complete_itinerary", limit=50)
 async def complete_itinerary(data: LandmarkSelection):
     try:
         logging.info(f"Received complete-itinerary request: {data.model_dump()}")

--- a/app/places_client.py
+++ b/app/places_client.py
@@ -9,6 +9,7 @@ import json
 import asyncio # Added asyncio for TimeoutError
 from dateutil import parser as date_parser
 from .routes_client import GoogleRoutesClient # Ensure this is the new async version
+from .redis_client import RedisClient
 
 class RateLimit:
     def __init__(self, limit: int, window: int):
@@ -34,9 +35,8 @@ class RateLimit:
         return False
 
 class RedisCache:
-    def __init__(self, redis_url: str):
-        self.redis_url = redis_url
-        self.client: Optional[aioredis.Redis] = None # Updated type hint
+    def __init__(self, redis_client: Optional[RedisClient] = None):
+        self.redis_client = redis_client or RedisClient()
         self.ttl = {
             'geocode': 7 * 24 * 60 * 60,  # 1 week
             'places': 24 * 60 * 60,       # 24 hours
@@ -44,22 +44,6 @@ class RedisCache:
             'image_proxy': 7 * 24 * 60 * 60 # 1 week for proxied images
         }
         self.logger = logging.getLogger(__name__)
-
-    async def get_client(self) -> aioredis.Redis:
-        if self.client is None:
-            # Use redis.asyncio.from_url with optimized settings
-            self.client = aioredis.from_url(
-                self.redis_url,
-                encoding="utf-8",
-                decode_responses=False,
-                retry_on_timeout=True,
-                socket_timeout=2,  # Reduce timeout to fail fast
-                socket_connect_timeout=2,
-                socket_keepalive=True,
-                health_check_interval=30,
-                max_connections=10  # Limit connections to prevent overwhelming Redis
-            )
-        return self.client
 
     def get_key(self, key_type: str, **kwargs) -> str:
         # Use a more efficient cache key format
@@ -86,51 +70,26 @@ class RedisCache:
         return f"{version_prefix}:{base_key}" if base_key else ""
 
     async def get(self, key: str) -> Optional[Any]:
-        client = await self.get_client()
-        try:
-            # Add timeout to Redis get operation
-            data = await asyncio.wait_for(
-                client.get(key),
-                timeout=2.0  # 2 second timeout
-            )
-            
-            if not data:
-                return None
-                
-            # If key starts with image_proxy prefix, return raw bytes
-            if key.startswith(f"{self.get_key('image_proxy', photoreference='').split(':')[0]}:img"):
-                self.logger.info(f"Retrieved image from cache for key: {key}")
-                return data
-                
-            # For other data types, try to decode JSON
-            try:
-                return json.loads(data.decode('utf-8'))
-            except (UnicodeDecodeError, json.JSONDecodeError) as e:
-                self.logger.error(f"Error decoding data for key {key}: {str(e)}")
-                return None
-                
-        except asyncio.TimeoutError:
-            self.logger.warning(f"Redis get timeout for key {key}")
+        """Get value from cache using RedisClient"""
+        data = await self.redis_client.get(key)
+        
+        if not data:
             return None
-        except Exception as e:
-            self.logger.error(f"Redis get error for key {key}: {str(e)}")
+            
+        # If key starts with image_proxy prefix, return raw bytes
+        if key.startswith(f"{self.get_key('image_proxy', photoreference='').split(':')[0]}:img"):
+            self.logger.debug(f"Retrieved image from cache for key: {key}")
+            return data
+            
+        # For other data types, try to decode JSON
+        try:
+            return json.loads(data.decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            self.logger.error(f"Error decoding data for key {key}: {str(e)}")
             return None
 
     async def set(self, key: str, value: Any, ttl_type: str):
-        client = await self.get_client()
-        try:
-            # Add timeout to Redis set operation
-            await asyncio.wait_for(
-                self._do_set(client, key, value, ttl_type),
-                timeout=2.0  # 2 second timeout
-            )
-        except asyncio.TimeoutError:
-            self.logger.warning(f"Redis set timeout for key {key}")
-        except Exception as e:
-            self.logger.error(f"Redis set error for key {key}: {str(e)}")
-
-    async def _do_set(self, client: aioredis.Redis, key: str, value: Any, ttl_type: str):
-        """Helper method to perform the actual Redis set operation"""
+        """Set value to cache using RedisClient"""
         # Handle binary data for images
         if ttl_type == 'image_proxy':
             if not isinstance(value, bytes):
@@ -143,18 +102,11 @@ class RedisCache:
 
         # Get TTL value, default to 1 hour if not found
         ttl = self.ttl.get(ttl_type, 3600)
-        await client.setex(key, ttl, data_to_store)
+        await self.redis_client.set(key, data_to_store, ttl)
         self.logger.debug(f"Successfully stored data in cache with key: {key}, ttl_type: {ttl_type}")
 
-    async def close(self):
-        if self.client:
-            await self.client.close()
-            await self.client.connection_pool.disconnect() # Ensure pool is disconnected
-            self.client = None
-            self.logger.info("Redis connection and pool closed.")
-
 class GooglePlacesClient:
-    def __init__(self, session: aiohttp.ClientSession):
+    def __init__(self, session: aiohttp.ClientSession, redis_client: Optional[RedisClient] = None):
         self.api_key = os.getenv('GOOGLE_PLACES_API_KEY')
         # Initialize GoogleRoutesClient with the same session
         self.routes_client = GoogleRoutesClient(session=session)
@@ -163,7 +115,7 @@ class GooglePlacesClient:
             'place_details': RateLimit(600, 60),
             'photos': RateLimit(600, 60)
         }
-        self.cache = RedisCache(os.getenv('REDIS_URL'))
+        self.cache = RedisCache(redis_client)
         self.logger = logging.getLogger(__name__)
         self._session = session # This client also uses the passed-in session
         # self._should_close_session should be False if session is always passed in via lifespan
@@ -610,12 +562,9 @@ class GooglePlacesClient:
             await self._session.close()
             self.logger.info("aiohttp ClientSession closed by GooglePlacesClient (because it created it).")
         
-        # Close RedisCache and GoogleRoutesClient
-        # GoogleRoutesClient.close() is currently a pass-through, as its session is managed externally.
-        # If GoogleRoutesClient had other resources, its close method would handle them.
-        await self.cache.close()
+        # Close GoogleRoutesClient
         await self.routes_client.close() # This will call the new async close in GoogleRoutesClient
-        self.logger.info("RedisCache and GoogleRoutesClient connections managed for closure by GooglePlacesClient.")
+        self.logger.info("GoogleRoutesClient connections managed for closure by GooglePlacesClient.")
 
     async def get_photo_url(self, photo_reference: str, max_width: int = 400, max_height: int = 400) -> Optional[str]:
         """Get photo URL from Google Places Photo API"""

--- a/app/preferences.py
+++ b/app/preferences.py
@@ -9,7 +9,8 @@ class PreferencesParser:
         self.client = OpenAI(
             api_key=os.getenv('OPENAI_API_KEY'),
             timeout=30.0,
-            max_retries=2
+            max_retries=2,
+            **({"base_url": os.getenv("OPENAI_BASE_URL")} if os.getenv("OPENAI_BASE_URL") else {})  # Use base_url if set, otherwise use default
         )
         self.logger = logging.getLogger(__name__)
 

--- a/app/rag.py
+++ b/app/rag.py
@@ -21,6 +21,7 @@ load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
 INDEX_NAME = os.getenv("INDEX_NAME")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
 
 if not OPENAI_API_KEY:
     raise ValueError("OPENAI_API_KEY environment variable is not set")
@@ -42,7 +43,8 @@ try:
         openai_api_key=OPENAI_API_KEY,
         model_name="gpt-4-turbo",
         temperature=0.5,
-        request_timeout=30  # 30 second timeout
+        request_timeout=30,  # 30 second timeout
+        **({"base_url": OPENAI_BASE_URL} if OPENAI_BASE_URL else {})  # Use base_url if set, otherwise use default
     )
     print("✅ Successfully initialized all API clients")
 except Exception as e:
@@ -322,6 +324,7 @@ def generate_structured_itinerary(
             if actual_count < min_required:
                 return {"error": f"Only {actual_count} valid items after filtering."}
             print(f"✅ Success in {time.time() - total_start:.2f}s")
+            print("result", result)
             return result.model_dump()
         except Exception as e:
             print(f"❌ Error validating result: {str(e)}")

--- a/app/redis_client.py
+++ b/app/redis_client.py
@@ -1,0 +1,179 @@
+import os
+import logging
+import asyncio
+from typing import Optional
+import redis.asyncio as aioredis
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class RedisClient:
+    """Redis client connection manager with async support"""
+    
+    def __init__(self, redis_url: Optional[str] = None):
+        self.redis_url = redis_url or os.getenv('REDIS_URL')
+        self.client: Optional[aioredis.Redis] = None
+        self.logger = logging.getLogger(__name__)
+        self._connection_lock = asyncio.Lock()
+
+    async def get_client(self) -> aioredis.Redis:
+        """Get Redis client instance, create new connection if not exists"""
+        if self.client is None:
+            async with self._connection_lock:
+                # Double-checked locking pattern
+                if self.client is None:
+                    await self._create_connection()
+        return self.client
+
+    async def _create_connection(self):
+        """Create Redis connection"""
+        try:
+            self.client = aioredis.from_url(
+                self.redis_url,
+                encoding="utf-8",
+                decode_responses=False,
+                retry_on_timeout=True,
+                socket_timeout=2,  # Reduce timeout to fail fast
+                socket_connect_timeout=2,
+                socket_keepalive=True,
+                health_check_interval=30,
+                max_connections=10  # Limit connections to prevent overwhelming Redis
+            )
+            self.logger.info("Redis connection created successfully")
+        except Exception as e:
+            self.logger.error(f"Failed to create Redis connection: {str(e)}")
+            raise
+
+    async def is_connected(self, timeout: float = 2.0) -> bool:
+        """Check if Redis connection is healthy"""
+        if self.client is None:
+            return False
+        
+        try:
+            await asyncio.wait_for(self.client.ping(), timeout=timeout)
+            return True
+        except Exception as e:
+            self.logger.warning(f"Redis connection check failed: {str(e)}")
+            return False
+
+    async def get(self, key: str, timeout: float = 2.0) -> Optional[bytes]:
+        """Get raw value from Redis with timeout and error handling"""
+        client = await self.get_client()
+        try:
+            # Add timeout to Redis get operation
+            data = await asyncio.wait_for(
+                client.get(key),
+                timeout=timeout
+            )
+            return data
+                
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis get timeout for key {key} (timeout: {timeout}s)")
+            return None
+        except Exception as e:
+            self.logger.error(f"Redis get error for key {key}: {str(e)}")
+            return None
+
+    async def set(self, key: str, value: bytes, ttl: int, timeout: float = 2.0):
+        """Set raw value in Redis with TTL and error handling"""
+        client = await self.get_client()
+        try:
+            # Add timeout to Redis set operation
+            await asyncio.wait_for(
+                client.setex(key, ttl, value),
+                timeout=timeout
+            )
+            self.logger.debug(f"Successfully stored data in Redis with key: {key}, ttl: {ttl}")
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis set timeout for key {key} (timeout: {timeout}s)")
+        except Exception as e:
+            self.logger.error(f"Redis set error for key {key}: {str(e)}")
+
+    async def delete(self, key: str, timeout: float = 2.0) -> bool:
+        """Delete key from Redis"""
+        client = await self.get_client()
+        try:
+            result = await asyncio.wait_for(
+                client.delete(key),
+                timeout=timeout
+            )
+            self.logger.debug(f"Deleted key from Redis: {key}")
+            return bool(result)
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis delete timeout for key {key} (timeout: {timeout}s)")
+            return False
+        except Exception as e:
+            self.logger.error(f"Redis delete error for key {key}: {str(e)}")
+            return False
+
+    async def exists(self, key: str, timeout: float = 2.0) -> bool:
+        """Check if key exists in Redis"""
+        client = await self.get_client()
+        try:
+            result = await asyncio.wait_for(
+                client.exists(key),
+                timeout=timeout
+            )
+            return bool(result)
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis exists timeout for key {key} (timeout: {timeout}s)")
+            return False
+        except Exception as e:
+            self.logger.error(f"Redis exists error for key {key}: {str(e)}")
+            return False
+
+    async def expire(self, key: str, seconds: int, timeout: float = 2.0) -> bool:
+        """Set expiration time for a key in Redis"""
+        client = await self.get_client()
+        try:
+            result = await asyncio.wait_for(
+                client.expire(key, seconds),
+                timeout=timeout
+            )
+            self.logger.debug(f"Set expiration for Redis key: {key}, seconds: {seconds}")
+            return bool(result)
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis expire timeout for key {key} (timeout: {timeout}s)")
+            return False
+        except Exception as e:
+            self.logger.error(f"Redis expire error for key {key}: {str(e)}")
+            return False
+
+    async def decr(self, key: str, timeout: float = 2.0) -> Optional[int]:
+        """Decrement the value of a key in Redis"""
+        client = await self.get_client()
+        try:
+            result = await asyncio.wait_for(
+                client.decr(key),
+                timeout=timeout
+            )
+            self.logger.debug(f"Decremented Redis key: {key}, new value: {result}")
+            return result
+        except asyncio.TimeoutError:
+            self.logger.warning(f"Redis decr timeout for key {key} (timeout: {timeout}s)")
+            return None
+        except Exception as e:
+            self.logger.error(f"Redis decr error for key {key}: {str(e)}")
+            return None
+
+    async def close(self):
+        """Close Redis connection"""
+        if self.client:
+            try:
+                await self.client.close()
+                await self.client.connection_pool.disconnect()
+                self.client = None
+                self.logger.info("Redis connection and pool closed")
+            except Exception as e:
+                self.logger.error(f"Error closing Redis connection: {str(e)}")
+
+    async def __aenter__(self):
+        """Async context manager entry"""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit"""
+        await self.close()
+
+# globally shared Redis client instance
+redis_client = RedisClient(os.getenv('REDIS_URL'))

--- a/decorators/rate_limit.py
+++ b/decorators/rate_limit.py
@@ -1,0 +1,57 @@
+# decorators/rate_limit.py
+import functools
+import datetime
+from fastapi import HTTPException
+from app.redis_client import redis_client
+
+def rate_limit(endpoint: str, limit: int):
+    """
+    Decorator to globally limit an API endpoint's requests per day using a decrementing counter.
+    
+    This decorator initializes a daily limit in Redis and decrements it on each request.
+    When the counter reaches zero or below, further requests are blocked until the next day.
+
+    Args:
+        endpoint (str): Redis key identifier for the specific endpoint.
+        limit (int): Maximum allowed requests per day (shared globally across all users).
+    
+    Raises:
+        HTTPException: When daily limit is exceeded (HTTP 429 - Too Many Requests).
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            
+            # Create a unique daily key for this endpoint
+            redis_key = f"rate_limit:api:{endpoint}"
+
+            # Get current remaining count, initialize with limit if key doesn't exist
+            current_count = await redis_client.get(redis_key)
+            
+            if current_count is None:
+                # First request of the day: initialize counter with the limit
+                await redis_client.set(redis_key, str(limit).encode(), ttl=86400)  # 24 hours TTL
+                current_count = limit
+                
+                # Set expiration to midnight of next day
+                tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+                midnight = datetime.datetime.combine(tomorrow.date(), datetime.time.min)
+                expire_seconds = int((midnight - datetime.datetime.now()).total_seconds())
+                await redis_client.expire(redis_key, expire_seconds)
+            else:
+                current_count = int(current_count.decode())
+
+            # Check if we have remaining requests
+            if current_count <= 0:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"Daily limit of {limit} requests exceeded for this endpoint. Try again tomorrow."
+                )
+
+            # Decrement the counter for this request
+            await redis_client.decr(redis_key)
+
+            # Execute the original function
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/scripts/test_setup.py
+++ b/scripts/test_setup.py
@@ -31,7 +31,8 @@ def test_openai():
         client = OpenAI(
             api_key=os.getenv('OPENAI_API_KEY'),
             timeout=30.0,
-            max_retries=2
+            max_retries=2,
+            **({"base_url": os.getenv("OPENAI_BASE_URL")} if os.getenv("OPENAI_BASE_URL") else {})  # Use base_url if set, otherwise use default
         )
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",


### PR DESCRIPTION
- It can be configured by setting the OPENAI_BASE_URL in the environment variables, which is used for creating the OpenAI client.
- - Add a new rate-limiting decorator for the API.
- Refactor the management of the Redis client by extracting it from the redisCache in GooglePlacesClient, adhering to the Single Responsibility Principle, and manage the Redis client using a globally shared instance.